### PR TITLE
Update data_mapper_setup.rb to work with Heroku

### DIFF
--- a/app/data_mapper_setup.rb
+++ b/app/data_mapper_setup.rb
@@ -9,6 +9,6 @@ require_relative 'models/user'
 # The name will be "bookmark_manager_test" or "bookmark_manager_development"
 # depending on the environment
 # DataMapper::Logger.new(STDOUT, :debug)
-DataMapper.setup(:default, "postgres://localhost/bookmark_manager_#{env}")
+DataMapper.setup(:default, ENV['DATABASE_URL'] || "postgres://localhost/bookmark_manager_#{env}")
 # After declaring your models, you should finalise them
 DataMapper.finalize


### PR DESCRIPTION
As per instructions here: https://devcenter.heroku.com/articles/rack

On this step: https://github.com/makersacademy/course/blob/master/bookmark_manager/bookmark_manager_stage_8.md

It discusses deploying to Heroku, maybe it would be nice to include this tweak to make it easier for others.

cc: @shadchnev
